### PR TITLE
chore: :wrench: modify pre_commit to format code before lint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-lint-staged
 pretty-quick --staged
+lint-staged


### PR DESCRIPTION
Изменил порядок команд для прекоммита.
 Теперь файлы сначала форматируются, а потом происходит проверка