### PR TITLE
Update footer styles for better centering of elements

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -27,7 +27,14 @@ const Footer: React.FC = observer(() => {
 
   const commonContent = (
     <>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: { xs: 'center', sm: 'unset' },
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
         <img src={Bird} alt="Logo." width={30} height={30} />
         <Typography variant="h6">TechDoc</Typography>
       </Box>
@@ -36,17 +43,22 @@ const Footer: React.FC = observer(() => {
         : isAuth
           ? renderLink('#', 'Часто задаваемые вопросы')
           : null}
-      <Typography variant="body2">© 2024</Typography>
+      <Typography
+        variant="body2"
+        sx={{ textAlign: { xs: 'center', sm: 'end' } }}
+      >
+        © 2024
+      </Typography>
     </>
   )
 
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'row' },
-        justifyContent: 'space-between',
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr', sm: '1fr 2fr 1fr' },
         alignItems: 'center',
+        gap: 2,
         p: { xs: '1rem', sm: '1.5rem' },
         backgroundColor: 'background.default',
         textAlign: 'center',


### PR DESCRIPTION
Было: 
![photo_5310040232265117167_y](https://github.com/user-attachments/assets/4224eb2f-6560-41fb-92d5-02aaa5be40d6)

Стало:
![footer-fix](https://github.com/user-attachments/assets/cb315fa7-4d18-46ba-83c2-f4a4a0c58289)
