### PR TITLE
changes-in-documents

### DIFF
--- a/src/components/autocomplete/autocomplete.tsx
+++ b/src/components/autocomplete/autocomplete.tsx
@@ -13,6 +13,9 @@ import { alpha } from '@mui/material/styles'
 import Paper from '@mui/material/Paper'
 import { CustomOption } from '@/components/autocomplete/option.tsx'
 import { CustomInput } from '@/components/autocomplete/input.tsx'
+import searchStore from '@/stores/SearchStore'
+import { Document } from '@/types/sharedTypes.ts'
+import authStore from '@/stores/AuthStore'
 
 interface GenericOption {
   id: number
@@ -99,7 +102,8 @@ const CustomAutocomplete = <T extends GenericOption>(
   const [inputValue, setInputValue] = useState('')
   const navigate = useNavigate()
   const theme = useTheme()
-
+  const { findDocumentById } = searchStore
+  const { user } = authStore
   const getOptionLabel = useCallback(
     (option: T) => {
       return displayFields.map((field) => option[field]).join('|')
@@ -138,12 +142,18 @@ const CustomAutocomplete = <T extends GenericOption>(
       setInputValue('')
 
       if (value && onValueAdd) {
-        setSelectedValue(null)
-        onValueAdd(value)
-        navigate(`${ROUTES.app('forward')}/${value.id}`)
+        const document: Document | null = findDocumentById(value.id)
+
+        if (document) {
+          setSelectedValue(null)
+          onValueAdd(value)
+          navigate(
+            `${ROUTES.app(document.user.id === user?.id ? 'forward' : 'inbox')}/${value.id}`
+          )
+        }
       }
     },
-    [navigate, onValueAdd]
+    [findDocumentById, navigate, onValueAdd, user?.id]
   )
 
   return (

--- a/src/components/createDocumentForm/documentForm/documentForm.tsx
+++ b/src/components/createDocumentForm/documentForm/documentForm.tsx
@@ -294,6 +294,7 @@ export const DocumentForm = (props: DocumentFormProps) => {
               control={control}
               render={({ field, fieldState }) => (
                 <DynamicFormField
+                  isFilled={!!field.value}
                   errorMessage={fieldState.error?.message}
                   title={attr.name}
                   required={attr.required}

--- a/src/components/createDocumentForm/dynamicFormField/dynamicFormField.tsx
+++ b/src/components/createDocumentForm/dynamicFormField/dynamicFormField.tsx
@@ -4,8 +4,11 @@ import Button from '@mui/material/Button'
 import FormControl from '@mui/material/FormControl'
 import { forwardRef, Ref, useCallback, useState } from 'react'
 import Box from '@mui/material/Box'
+import { IconButton } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 
 interface DynamicFormFieldProps {
+  isFilled: boolean
   title: string
   required: boolean
   errorMessage?: string
@@ -13,8 +16,9 @@ interface DynamicFormFieldProps {
 
 export const DynamicFormField = forwardRef(
   (props: DynamicFormFieldProps, ref: Ref<HTMLInputElement>) => {
-    const { title, required, errorMessage, ...otherProps } = props
-    const [visible, setVisible] = useState(required)
+    const { isFilled, title, required, errorMessage, ...otherProps } = props
+
+    const [visible, setVisible] = useState(isFilled || required)
 
     const handleShowField = useCallback(() => {
       setVisible((prev) => !prev)
@@ -41,11 +45,17 @@ export const DynamicFormField = forwardRef(
             flexShrink: 0,
           }}
         >
-          <Typography variant="body2">{title}</Typography>
+          <Typography variant="body2" sx={{ display: 'flex' }}>
+            {title}
+          </Typography>
+          <Typography variant="body2" color="red">
+            {required && '*'}
+          </Typography>
         </Box>
+
         {!required && !visible && (
           <Button
-            onClick={() => handleShowField()}
+            onClick={handleShowField}
             variant="text"
             sx={{
               '&.MuiButtonBase-root': {
@@ -56,6 +66,7 @@ export const DynamicFormField = forwardRef(
             Заполнить
           </Button>
         )}
+
         {visible && (
           <TextField
             fullWidth
@@ -67,6 +78,12 @@ export const DynamicFormField = forwardRef(
               htmlInput: { ...otherProps },
             }}
           />
+        )}
+
+        {!required && visible && (
+          <IconButton onClick={handleShowField} sx={{ color: 'primary.main' }}>
+            <CloseIcon />
+          </IconButton>
         )}
       </FormControl>
     )

--- a/src/components/documentDetails/documentActions/documentActions.tsx
+++ b/src/components/documentDetails/documentActions/documentActions.tsx
@@ -23,7 +23,7 @@ export const DocumentActions = (props: DocumentActionsProps) => {
           onClick={() => void button.onClick()}
           disabled={button.disabled}
         >
-          {button.content} {button.text && button.text}
+          {button.content} {button.text}
         </Button>
       ))}
     </Box>

--- a/src/components/documentDetails/documentComments/commentItem.tsx
+++ b/src/components/documentDetails/documentComments/commentItem.tsx
@@ -1,0 +1,66 @@
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import PersonIcon from '@mui/icons-material/Person'
+import { Comment } from '@/types/sharedTypes.ts'
+import { formatTimeAgo } from '@/utils/formatTimeAgo.ts'
+import { useTheme } from '@mui/material'
+
+interface CommentItemProps {
+  comment: Comment
+  isNew: boolean
+}
+
+export const CommentItem = (props: CommentItemProps) => {
+  const { comment, isNew } = props
+  const theme = useTheme()
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        p: 1,
+        borderRadius: '4px',
+        backgroundColor: isNew
+          ? theme.palette.mode === 'dark'
+            ? 'grey.800'
+            : 'grey.300'
+          : 'transparent',
+        transition: 'background-color 0.3s',
+      }}
+    >
+      <PersonIcon
+        sx={{
+          width: '2.5rem',
+          height: '2.5rem',
+          color: 'grey.600',
+        }}
+      />
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.2rem',
+        }}
+      >
+        <Box>
+          <Typography
+            variant="caption"
+            sx={{
+              fontWeight: 600,
+              pr: 0.5,
+              color: 'primary.dark',
+            }}
+          >
+            {comment.author.name} {comment.author.surname}
+          </Typography>
+          <Typography variant="caption" sx={{ color: 'grey.500' }}>
+            {formatTimeAgo(comment.createdAt)}
+          </Typography>
+        </Box>
+        <Typography variant="body2">{comment.content}</Typography>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/documentDetails/documentDetails.tsx
+++ b/src/components/documentDetails/documentDetails.tsx
@@ -5,22 +5,38 @@ import { DocumentActions } from '@/components/documentDetails/documentActions/do
 import Divider from '@mui/material/Divider'
 import { DocumentComments } from '@/components/documentDetails/documentComments/documentComments.tsx'
 import { useMediaQuery, useTheme } from '@mui/material'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import DocumentStore from '@/stores/DocumentStore'
 import { getNavigationType } from '@/components/appDashboardLayout/navigation/getNavigationType.ts'
 import { useActionButtons } from '@/components/documentDetails/useActionButtons.tsx'
 import { FilePreviewModal } from '@/components/documentDetails/filePreview/filePreviewModal.tsx'
 import { useLocation } from 'react-router-dom'
+import { observer } from 'mobx-react-lite'
+import { NavigationType } from '@/components/appDashboardLayout/navigation/types.ts'
+import { DocumentTransitions } from '@/api/documentController/types.ts'
 
 interface DocumentDetailsProps {
+  selectedVersionIndex: number
+  onVersionSelect: (index: number) => void
   documentStore: DocumentStore
 }
 
-export const DocumentDetails = (props: DocumentDetailsProps) => {
-  const { documentStore } = props
+export const DocumentDetails = observer((props: DocumentDetailsProps) => {
+  const { selectedVersionIndex, onVersionSelect, documentStore } = props
   const document = documentStore.documentData
+
   const location = useLocation()
   const navigationType = getNavigationType(location.pathname)
+
+  useEffect(() => {
+    void (async () => {
+      if (navigationType === NavigationType.DELETED) {
+        await documentStore.getDocumentTransitions(false)
+      } else {
+        await documentStore.getDocumentTransitions()
+      }
+    })()
+  }, [documentStore, navigationType])
 
   const theme = useTheme()
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'))
@@ -34,16 +50,8 @@ export const DocumentDetails = (props: DocumentDetailsProps) => {
     setModalOpen(true)
   }, [])
 
-  const [selectedVersionIndex, setSelectedVersionIndex] = useState(
-    document.documentVersions.length - 1
-  )
-
-  const handleVersionSelect = useCallback((index: number) => {
-    setSelectedVersionIndex(index)
-  }, [])
-
   const actionButtons = useActionButtons(
-    navigationType,
+    documentStore.transitions,
     document,
     selectedVersionIndex,
     handlePreview
@@ -74,15 +82,22 @@ export const DocumentDetails = (props: DocumentDetailsProps) => {
         />
         <DocumentVersionList
           documentVersions={document.documentVersions}
-          onVersionSelect={handleVersionSelect}
+          onVersionSelect={onVersionSelect}
           selectedVersionIndex={selectedVersionIndex}
         />
         <DocumentActions buttons={actionButtons} />
       </Box>
 
-      {isLargeScreen && <Divider orientation="vertical" flexItem />}
+      {isLargeScreen &&
+        (document.state !== DocumentTransitions.DELETED ||
+          document.comments.length > 0) && (
+          <Divider orientation="vertical" flexItem />
+        )}
 
-      <DocumentComments documentStore={documentStore} />
+      {(document.state !== DocumentTransitions.DELETED ||
+        document.comments.length > 0) && (
+        <DocumentComments documentStore={documentStore} />
+      )}
 
       {modalOpen && (
         <FilePreviewModal
@@ -93,4 +108,4 @@ export const DocumentDetails = (props: DocumentDetailsProps) => {
       )}
     </Box>
   )
-}
+})

--- a/src/components/documentDetails/documentHeader/documentHeader.tsx
+++ b/src/components/documentDetails/documentHeader/documentHeader.tsx
@@ -12,7 +12,7 @@ import DocumentStore from '@/stores/DocumentStore'
 
 interface DocumentHeaderProps {
   isChecked: boolean
-  onChangeSwitch: (event: ChangeEvent<HTMLInputElement>) => void
+  onChangeSwitch?: (event: ChangeEvent<HTMLInputElement>) => void
   isLatestVersion?: boolean
   documentStore?: DocumentStore | null
 }

--- a/src/components/documentDetails/documentHeader/documentHeader.tsx
+++ b/src/components/documentDetails/documentHeader/documentHeader.tsx
@@ -6,14 +6,19 @@ import { StyledSwitch } from '@/components/styled/switch.tsx'
 import { useTheme } from '@mui/material'
 import { ChangeEvent, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { DocumentTransitions } from '@/api/documentController/types.ts'
+import { observer } from 'mobx-react-lite'
+import DocumentStore from '@/stores/DocumentStore'
 
 interface DocumentHeaderProps {
   isChecked: boolean
   onChangeSwitch: (event: ChangeEvent<HTMLInputElement>) => void
+  isLatestVersion?: boolean
+  documentStore?: DocumentStore | null
 }
 
-export const DocumentHeader = (props: DocumentHeaderProps) => {
-  const { isChecked, onChangeSwitch } = props
+export const DocumentHeader = observer((props: DocumentHeaderProps) => {
+  const { isChecked, onChangeSwitch, isLatestVersion, documentStore } = props
   const theme = useTheme()
   const navigate = useNavigate()
 
@@ -37,24 +42,28 @@ export const DocumentHeader = (props: DocumentHeaderProps) => {
           В список документов
         </Typography>
       </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '0.5rem',
-        }}
-      >
-        <StyledSwitch checked={isChecked} onChange={onChangeSwitch} />
-        <Typography
-          variant="caption"
-          sx={{
-            m: 0,
-            color: theme.palette.mode === 'dark' ? 'grey.400' : 'grey.600',
-          }}
-        >
-          Редактировать
-        </Typography>
-      </Box>
+      {documentStore &&
+        documentStore.transitions?.includes(DocumentTransitions.MODIFIED) &&
+        isLatestVersion && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}
+          >
+            <StyledSwitch checked={isChecked} onChange={onChangeSwitch} />
+            <Typography
+              variant="caption"
+              sx={{
+                m: 0,
+                color: theme.palette.mode === 'dark' ? 'grey.400' : 'grey.600',
+              }}
+            >
+              Редактировать
+            </Typography>
+          </Box>
+        )}
     </Box>
   )
-}
+})

--- a/src/components/documentDetails/documentInfo/documentInfo.tsx
+++ b/src/components/documentDetails/documentInfo/documentInfo.tsx
@@ -5,6 +5,7 @@ import Divider from '@mui/material/Divider'
 import { DocumentVersion } from '@/types/sharedTypes.ts'
 import { useLocation } from 'react-router-dom'
 import { getNavigationType } from '@/components/appDashboardLayout/navigation/getNavigationType.ts'
+import { useMemo } from 'react'
 
 interface DocumentInfoProps {
   documentVersions: DocumentVersion[]
@@ -30,22 +31,36 @@ export const DocumentInfo = (props: DocumentInfoProps) => {
   const documentDescription = documentVersions[selectedVersionIndex].description
   const documentCreatedAt = documentVersions[selectedVersionIndex].createdAt
   const documentSignatures = documentVersions[selectedVersionIndex].signatures
+  const documentFile =
+    documentVersions[selectedVersionIndex].base64Content?.split(',')[0]
+  const filename = useMemo(() => {
+    if (documentFile) {
+      const filenameMatch = documentFile.match(/filename:([^;]+)/)
+
+      return filenameMatch ? filenameMatch[1] : ''
+    }
+  }, [documentFile])
 
   return (
     <>
       <Box>
         <Typography variant="h5" sx={{ fontWeight: 600, pb: 1 }}>
           {navigationType ? navigationLabels[navigationType] : 'Документ'}{' '}
-          {documentTitle}
+          {`"${documentTitle}"`}
         </Typography>
         <Divider sx={{ backgroundColor: 'primary.main' }} />
       </Box>
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
-        <Typography variant="body2" gutterBottom>
-          {documentName} от{' '}
-          {new Date(documentCreatedAt).toLocaleDateString('ru-RU')}
-        </Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Typography variant="body2" gutterBottom>
+            {documentName} от{' '}
+            {new Date(documentCreatedAt).toLocaleDateString('ru-RU')}
+          </Typography>
+          <Typography variant="caption" color="primary.main">
+            {filename}
+          </Typography>
+        </Box>
 
         <Typography variant="body2" gutterBottom>
           Отправитель:{' '}

--- a/src/components/documentDetails/filePreview/filePreviewModal.tsx
+++ b/src/components/documentDetails/filePreview/filePreviewModal.tsx
@@ -47,7 +47,7 @@ export const FilePreviewModal = (props: FilePreviewModalProps) => {
             style={{
               cursor: zoomed ? 'zoom-out' : 'zoom-in',
               maxWidth: isSmallScreen ? '100%' : 'none',
-              maxHeight: isSmallScreen ? '100%' : 'none',
+              maxHeight: '100%',
               transition: 'transform 0.4s ease',
               willChange: 'transform',
               transform: zoomed

--- a/src/components/documentsList/documentsList.tsx
+++ b/src/components/documentsList/documentsList.tsx
@@ -16,6 +16,7 @@ import { alpha } from '@mui/material/styles'
 import { GridPaginationModel } from '@mui/x-data-grid/models/gridPaginationProps'
 import { ToolbarButton } from '@/types/types'
 import { GridFeatureMode } from '@mui/x-data-grid/models/gridFeatureMode'
+import { observer } from 'mobx-react-lite'
 
 export const DEFAULT_PAGE_SIZE = 15
 export const DEFAULT_PAGE = 0
@@ -34,122 +35,154 @@ interface DocumentsListProps<T extends GridValidRowModel> {
   onPaginationModelChange?: (paginationModel: GridPaginationModel) => void
   paginationMode?: GridFeatureMode
   onRowClick?: (params: GridRowParams) => void
+  loading?: boolean
 }
 
-export const DocumentsList = <T extends GridValidRowModel>(
-  props: DocumentsListProps<T>
-) => {
-  const {
-    rows,
-    columns,
-    totalDocuments,
-    initialPage = DEFAULT_PAGE,
-    initialPageSize = DEFAULT_PAGE_SIZE,
-    paginationOption = DEFAULT_PAGINATION_OPTIONS,
-    buttons,
-    selectionModel,
-    onSelectionChange,
-    onPaginationModelChange,
-    paginationMode = 'server',
-    onRowClick,
-  } = props
+export const DocumentsList = observer(
+  <T extends GridValidRowModel>(props: DocumentsListProps<T>) => {
+    const {
+      rows,
+      columns,
+      totalDocuments,
+      initialPage = DEFAULT_PAGE,
+      initialPageSize = DEFAULT_PAGE_SIZE,
+      paginationOption = DEFAULT_PAGINATION_OPTIONS,
+      buttons,
+      selectionModel,
+      onSelectionChange,
+      onPaginationModelChange,
+      paginationMode = 'server',
+      onRowClick,
+      loading,
+    } = props
 
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
-    page: initialPage,
-    pageSize: initialPageSize,
-  })
-
-  const theme = useTheme()
-
-  const handleRowSelectionModelChange = useCallback(
-    (newSelectionModel: GridRowSelectionModel) => {
-      if (onSelectionChange) {
-        onSelectionChange(newSelectionModel)
+    const [paginationModel, setPaginationModel] = useState<GridPaginationModel>(
+      {
+        page: initialPage,
+        pageSize: initialPageSize,
       }
-    },
-    [onSelectionChange]
-  )
+    )
 
-  const handlePaginationModelChange = useCallback(
-    (paginationModel: GridPaginationModel) => {
-      setPaginationModel(paginationModel)
-      if (onPaginationModelChange) {
-        onPaginationModelChange(paginationModel)
+    const theme = useTheme()
+
+    const handleRowSelectionModelChange = useCallback(
+      (newSelectionModel: GridRowSelectionModel) => {
+        if (onSelectionChange) {
+          onSelectionChange(newSelectionModel)
+        }
+      },
+      [onSelectionChange]
+    )
+
+    const handlePaginationModelChange = useCallback(
+      (paginationModel: GridPaginationModel) => {
+        setPaginationModel(paginationModel)
+        if (onPaginationModelChange) {
+          onPaginationModelChange(paginationModel)
+        }
+      },
+      [onPaginationModelChange]
+    )
+
+    const rowCount = useMemo(() => {
+      if (paginationMode === 'server') {
+        return totalDocuments
       }
-    },
-    [onPaginationModelChange]
-  )
 
-  const rowCount = useMemo(() => {
-    if (paginationMode === 'server') {
-      return totalDocuments
-    }
+      return
+    }, [paginationMode, totalDocuments])
 
-    return
-  }, [paginationMode, totalDocuments])
-
-  return (
-    <>
-      <Paper>
-        <DataGrid
-          rows={rows}
-          columns={columns}
-          paginationMode={paginationMode}
-          paginationModel={paginationModel}
-          onPaginationModelChange={handlePaginationModelChange}
-          rowCount={rowCount}
-          pageSizeOptions={paginationOption}
-          checkboxSelection
-          disableVirtualization
-          disableColumnMenu
-          disableRowSelectionOnClick
-          onRowSelectionModelChange={handleRowSelectionModelChange}
-          rowSelectionModel={selectionModel}
-          onRowClick={onRowClick}
-          localeText={{
-            footerRowSelected: (count) => `${count} выбрано`,
-            noResultsOverlayLabel: 'Нет результатов',
-            toolbarColumns: 'Столбцы',
-            toolbarColumnsLabel: 'Управление столбцами',
-            toolbarFilters: 'Фильтры',
-            toolbarFiltersLabel: 'Фильтры',
-            toolbarExport: 'Экспорт',
-            toolbarExportLabel: 'Экспортировать',
-            toolbarExportCSV: 'Экспорт в CSV',
-            toolbarExportPrint: 'Печать',
-            toolbarExportExcel: 'Экспорт в Excel',
-          }}
-          slots={{
-            pagination: (props) => (
-              <GridPagination
-                {...props}
-                labelDisplayedRows={({ from, to, count }) => {
-                  return ` ${from}-${to} из ${count}`
-                }}
-                labelRowsPerPage="Документов на странице:"
-              />
-            ),
-            toolbar: () => <GridToolbar buttons={buttons} />,
-          }}
-          sx={{
-            '--DataGrid-overlayHeight': '300px',
-            '& .MuiDataGrid-cell': {
-              '&:focus': {
-                outline: 'none',
+    return (
+      <>
+        <Paper sx={{ width: '100%', maxHeight: '54rem' }}>
+          <DataGrid
+            rows={rows}
+            columns={columns}
+            loading={loading}
+            paginationMode={paginationMode}
+            paginationModel={paginationModel}
+            onPaginationModelChange={handlePaginationModelChange}
+            rowCount={rowCount}
+            pageSizeOptions={paginationOption}
+            checkboxSelection
+            disableColumnMenu
+            disableRowSelectionOnClick
+            disableVirtualization
+            onRowSelectionModelChange={handleRowSelectionModelChange}
+            rowSelectionModel={selectionModel}
+            onRowClick={onRowClick}
+            localeText={{
+              footerRowSelected: (count) => `${count} выбрано`,
+              noRowsLabel: 'Документов нет',
+              noResultsOverlayLabel: 'Нет результатов',
+              toolbarColumns: 'Столбцы',
+              toolbarColumnsLabel: 'Управление столбцами',
+              toolbarFilters: 'Фильтры',
+              toolbarFiltersLabel: 'Фильтры',
+              toolbarExport: 'Экспорт',
+              toolbarExportLabel: 'Экспортировать',
+              toolbarExportCSV: 'Экспорт в CSV',
+              toolbarExportPrint: 'Печать',
+              toolbarExportExcel: 'Экспорт в Excel',
+            }}
+            slotProps={{
+              loadingOverlay: {
+                variant: 'skeleton',
+                noRowsVariant: 'skeleton',
               },
-            },
-            '& .MuiDataGrid-row': {
-              '&:hover': {
-                boxShadow: theme.shadows[3],
+              toolbar: {
+                showQuickFilter: true,
               },
-              '&:focus-within': {
-                backgroundColor: alpha(theme.palette.primary.main, 0.1),
+            }}
+            slots={{
+              pagination: (props) => (
+                <GridPagination
+                  {...props}
+                  labelDisplayedRows={({ from, to, count }) => {
+                    return ` ${from}-${to} из ${count}`
+                  }}
+                  labelRowsPerPage="Документов на странице:"
+                />
+              ),
+              toolbar: () => <GridToolbar buttons={buttons} />,
+            }}
+            sx={{
+              '& .MuiDataGrid-scrollbar': {
+                '&::-webkit-scrollbar': {
+                  width: '0.4rem',
+                  height: '0.4rem',
+                },
+                '&::-webkit-scrollbar-thumb': {
+                  background: 'grey',
+                  borderRadius: '0.5rem',
+                },
               },
-            },
-          }}
-        />
-      </Paper>
-      <Outlet />
-    </>
-  )
-}
+              '&.MuiDataGrid-root': {
+                minHeight: '13rem',
+                maxHeight: '52rem',
+              },
+              '& .MuiDataGrid-overlayWrapper': {
+                flex: 1,
+              },
+              '& .MuiDataGrid-cell': {
+                '&:focus': {
+                  outline: 'none',
+                },
+              },
+              '& .MuiDataGrid-row': {
+                cursor: 'pointer',
+                '&:hover': {
+                  boxShadow: theme.shadows[3],
+                },
+                '&:focus-within': {
+                  backgroundColor: alpha(theme.palette.primary.main, 0.1),
+                },
+              },
+            }}
+          />
+        </Paper>
+        <Outlet />
+      </>
+    )
+  }
+)

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -21,16 +21,24 @@ export const Search = observer(() => {
   const { documentsSize, countTotalDocuments } = documentsListStore
 
   const [openModal, setOpenModal] = useState(false)
+  // const [countAllDocuments, setCountAllDocuments] = useState(0)
 
   useEffect(() => {
     void (async () => {
       if (!documentsSize) {
-        await countTotalDocuments()
-      } else {
-        await fetchAllDocuments()
+        const result = await countTotalDocuments()
+
+        if (result) {
+          await fetchAllDocuments(result)
+        }
       }
     })()
-  }, [countTotalDocuments, documentsSize, fetchAllDocuments])
+  }, [
+    allDocuments.length,
+    countTotalDocuments,
+    documentsSize,
+    fetchAllDocuments,
+  ])
 
   const addToSearchHistory = useCallback(
     (value: DocumentVersion) => {

--- a/src/components/search/searchModal/searchModal.tsx
+++ b/src/components/search/searchModal/searchModal.tsx
@@ -15,6 +15,8 @@ import {
   renderNoResults,
   renderRecentSearches,
 } from '@/components/search/searchModal/searchModalRenderers.tsx'
+import authStore from '@/stores/AuthStore'
+import searchStore from '@/stores/SearchStore'
 
 interface SearchModalProps {
   openModal: boolean
@@ -38,6 +40,8 @@ export const SearchModal = (props: SearchModalProps) => {
   const [searchQuery, setSearchQuery] = useState('')
   const navigate = useNavigate()
   const theme = useTheme()
+  const { user } = authStore
+  const { findDocumentById } = searchStore
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -64,9 +68,15 @@ export const SearchModal = (props: SearchModalProps) => {
     (documentInfo: DocumentVersion) => {
       onValueAdd(documentInfo)
       onCloseModal()
-      navigate(`${ROUTES.app('forward')}/${documentInfo.id}`)
+      const document = findDocumentById(documentInfo.id)
+
+      if (document) {
+        navigate(
+          `${ROUTES.app(document.user.id === user?.id ? 'forward' : 'inbox')}/${documentInfo.id}`
+        )
+      }
     },
-    [onValueAdd, onCloseModal, navigate]
+    [onValueAdd, onCloseModal, findDocumentById, navigate, user?.id]
   )
 
   return (

--- a/src/components/search/searchModal/searchModalRenderers.tsx
+++ b/src/components/search/searchModal/searchModalRenderers.tsx
@@ -1,8 +1,8 @@
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-import FindInPageIcon from '@mui/icons-material/FindInPage'
 import { DocumentVersion } from '@/types/sharedTypes.ts'
 import { DocumentItem } from '@/components/search/documentItem/documentItem.tsx'
+import SearchOffIcon from '@mui/icons-material/SearchOff'
 
 interface RenderDocumentItemsProps {
   documents: DocumentVersion[]
@@ -33,7 +33,7 @@ export const renderNoResults = (searchQuery: string) => (
       gap: '1rem',
     }}
   >
-    <FindInPageIcon
+    <SearchOffIcon
       sx={{ color: 'grey.500', width: '2.5rem', height: '2.5rem' }}
     />
     <Typography>

--- a/src/mock/documentPage/index.tsx
+++ b/src/mock/documentPage/index.tsx
@@ -1,6 +1,6 @@
 import { Loader } from '@/components/loader'
 import { useNotifications } from '@toolpad/core'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import documentsSignService from '@/stores/DocumentsSignService'
 import { observer } from 'mobx-react-lite'
@@ -16,6 +16,11 @@ export const DocumentPage = observer(() => {
   const notifications = useNotifications()
   const navigate = useNavigate()
   const document = documentId ? documents[documentId] : null
+
+  const [selectedVersionIndex, setSelectedVersionIndex] = useState(0)
+  const handleVersionSelect = useCallback((index: number) => {
+    setSelectedVersionIndex(index)
+  }, [])
 
   useEffect(() => {
     if (documentId) void fetchDocumentById(Number(documentId))
@@ -54,7 +59,13 @@ export const DocumentPage = observer(() => {
       >
         <DocumentHeader isChecked={false} onChangeSwitch={() => {}} />
 
-        {document && <DocumentDetails documentStore={document} />}
+        {document && (
+          <DocumentDetails
+            documentStore={document}
+            selectedVersionIndex={selectedVersionIndex}
+            onVersionSelect={handleVersionSelect}
+          />
+        )}
         <SignatureBlock document={document} />
       </Paper>
     </Modal>

--- a/src/mock/documentPage/index.tsx
+++ b/src/mock/documentPage/index.tsx
@@ -17,11 +17,6 @@ export const DocumentPage = observer(() => {
   const navigate = useNavigate()
   const document = documentId ? documents[documentId] : null
 
-  const [selectedVersionIndex, setSelectedVersionIndex] = useState(0)
-  const handleVersionSelect = useCallback((index: number) => {
-    setSelectedVersionIndex(index)
-  }, [])
-
   useEffect(() => {
     if (documentId) void fetchDocumentById(Number(documentId))
   }, [documentId, fetchDocumentById])
@@ -41,6 +36,13 @@ export const DocumentPage = observer(() => {
 
   if (loading) return <Loader />
   if (!document) return null
+
+  const lastIndex = document.documentData.documentVersions.length - 1
+  const [selectedVersionIndex, setSelectedVersionIndex] = useState(lastIndex)
+
+  const handleVersionSelect = useCallback((index: number) => {
+    setSelectedVersionIndex(index)
+  }, [])
 
   return (
     <Modal open={!!documentId} onClose={handleClose}>

--- a/src/pages/draftPage/index.tsx
+++ b/src/pages/draftPage/index.tsx
@@ -65,23 +65,29 @@ const columns: GridColDef<RowData>[] = [
 
 export const DraftPage = observer(() => {
   const {
+    loading,
     deleteDocument,
     fetchDocuments,
     documents,
     countTotalDocuments,
-    documentsSize,
   } = documentsListStore
   const [selectionModel, setSelectionModel] = useState<GridRowId[]>([])
+  const [countTotalDraftSize, setCountTotalDraftSize] = useState(0)
 
   useEffect(() => {
-    void countTotalDocuments(true, true)
+    void (async () => {
+      const result = await countTotalDocuments(true, true)
+      if (result) {
+        setCountTotalDraftSize(result)
+      }
 
-    void fetchDocuments({
-      page: DEFAULT_PAGE,
-      size: DEFAULT_PAGE_SIZE,
-      showDraft: true,
-    })
-  }, [countTotalDocuments, documentsSize, fetchDocuments])
+      await fetchDocuments({
+        page: DEFAULT_PAGE,
+        size: DEFAULT_PAGE_SIZE,
+        showDraft: true,
+      })
+    })()
+  }, [countTotalDocuments, fetchDocuments])
 
   const notifications = useNotifications()
   const navigate = useNavigate()
@@ -176,8 +182,9 @@ export const DraftPage = observer(() => {
         buttons={buttons}
         onSelectionChange={handleChange}
         onPaginationModelChange={handlePaginationModelChange}
-        totalDocuments={documentsSize}
+        totalDocuments={countTotalDraftSize}
         onRowClick={handleRowClick}
+        loading={loading}
       />
     </PageContainer>
   )

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -89,6 +89,12 @@ export const appRoutes = [
           {
             path: ROUTES.app('deleted'),
             Component: DeletedPage,
+            children: [
+              {
+                path: ':id',
+                Component: DocumentPage,
+              },
+            ],
           },
           {
             path: ROUTES.app(':journal'),

--- a/src/stores/DocumentStore/DocumentStore.ts
+++ b/src/stores/DocumentStore/DocumentStore.ts
@@ -1,4 +1,4 @@
-import { makeAutoObservable, runInAction } from 'mobx'
+import { makeAutoObservable, reaction, runInAction } from 'mobx'
 import {
   documentControllerApi,
   DocumentVersionModel,
@@ -18,6 +18,12 @@ class DocumentStore {
     makeAutoObservable(this)
 
     this.documentData = document
+    reaction(
+      () => this.documentData,
+      () => {
+        void this.getDocumentTransitions()
+      }
+    )
   }
 
   patchDocumentVersion = async (

--- a/src/stores/DocumentsListStore/DocumentsListStore.ts
+++ b/src/stores/DocumentsListStore/DocumentsListStore.ts
@@ -107,6 +107,8 @@ class DocumentsListStore {
         this.documentsSize = countDocuments
       })
     }
+
+    return countDocuments
   }
 }
 

--- a/src/stores/SearchStore/SearchStore.ts
+++ b/src/stores/SearchStore/SearchStore.ts
@@ -3,7 +3,6 @@ import { SerializedError } from '@/api/core/serializedError.ts'
 import { makeAutoObservable, runInAction } from 'mobx'
 import { executeWithLoading } from '@/utils/executeWithLoading.ts'
 import { documentControllerApi } from '@/api/documentController'
-import documentsListStore from '@/stores/DocumentsListStore'
 
 class SearchStore {
   allDocuments: Document[] = []
@@ -15,9 +14,7 @@ class SearchStore {
     makeAutoObservable(this)
   }
 
-  fetchAllDocuments = async () => {
-    const { documentsSize } = documentsListStore
-
+  fetchAllDocuments = async (documentsSize: number) => {
     await this.loadDocuments(documentsSize)
   }
 
@@ -39,6 +36,10 @@ class SearchStore {
         this.searchHistory.push(documentVersion)
       })
     }
+  }
+
+  findDocumentById = (id: number) => {
+    return this.allDocuments.find((document) => document.id === id) || null
   }
 }
 

--- a/src/types/sharedTypes.ts
+++ b/src/types/sharedTypes.ts
@@ -1,5 +1,3 @@
-import { DocumentTransitions } from '@/api/documentController/types'
-
 // user-controller
 import { DocumentTransitions } from '@/api/documentController/types.ts'
 


### PR DESCRIPTION
- Теперь во вкладке удаленные при клике появляется карточка, которую нельзя отредактировать и оставить комментарии
- При изменении documentData теперь вызывается метод, который получает доступные transitions
- Кнопки для карточки документа теперь рисуются на основе доступных transitions 
- Редактирование документа возможно, если есть доступный transition и это последняя версия документа 
- Обновлены стиля, теперь комментарии скрываются, если их больше 3 
- В форме создания документа теперь появились звездочки рядом с обязательными атрибутами и крестики, благодаря которым можно скрывать необязательные поля 
- Обновлена таблица документов, теперь там при loading появляется скелетон
- обновлен поиск и сторы, связанные с ним. Раньше его переопределял documentsListStore, теперь он берет все документы и смотрит, совпадают ли они с юзером и перенаправляет на нужную страницу
- documentsSize при вызове метода countTotalDocuments постоянно переопределялся и показывал на странице не то количество, сейчас это сделано, пока что, через локальное состояние 
- Таблица исходящих сделана через клиентскую пагинацию, отсеивая входящие документы от других пользователей

форма создания документа
![image](https://github.com/user-attachments/assets/9a51f368-f5a2-48c9-aa23-6ba439494cd6)
снекбар в таблице
![image](https://github.com/user-attachments/assets/b55694e8-1932-437b-9fd1-745da367957e)

Карточка удаленного документа без комментариев и редактирования 
![image](https://github.com/user-attachments/assets/54912570-fe3e-44c1-905c-38083d4a4665)

Карточка документа в исходящих
![image](https://github.com/user-attachments/assets/e016362d-6c56-412b-91d5-acb7a07b8422)
