### PR TITLE
disabled server-side pagination

### DIFF
--- a/src/pages/AttributesPage/components/AttributeTable/index.tsx
+++ b/src/pages/AttributesPage/components/AttributeTable/index.tsx
@@ -109,11 +109,11 @@ const AttributeTable = (props: Props) => {
         rows={props.rows}
         disableRowSelectionOnClick
         getRowHeight={() => 'auto'}
-        paginationMode="server"
+        // paginationMode="server"
         paginationModel={props.paginationModel}
         onPaginationModelChange={props.onPaginationModelChange}
         pageSizeOptions={[10, 20, 40]}
-        rowCount={props.rowCount}
+        //rowCount={props.rowCount}
         slots={{
           pagination: () => (
             <GridPagination labelRowsPerPage={'Аттрибутов на странице'} />

--- a/src/pages/AttributesPage/index.tsx
+++ b/src/pages/AttributesPage/index.tsx
@@ -67,11 +67,11 @@ const AttributesPage = (props: Props) => {
   }, [success])
   const fetchAliveData = async () => {
     try {
-      const { page, pageSize } = paginationModel
+      // const { page, pageSize } = paginationModel
       await attributeListStore.fetchAttributes({
         showOnlyAlive: true,
-        page: page,
-        size: pageSize,
+        // page: page,
+        // size: pageSize,
       })
       const fetchedAliveAttributes = getAttributes()
       await documentTypeListStore.fetchDocumentTypes()
@@ -95,11 +95,11 @@ const AttributesPage = (props: Props) => {
   }
   const fetchDeadData = async () => {
     try {
-      const { page, pageSize } = paginationModel
+      // const { page, pageSize } = paginationModel
       await attributeListStore.fetchAttributes({
         showOnlyAlive: false,
-        page: page,
-        size: pageSize,
+        // page: page,
+        // size: pageSize,
       })
       const fetchedDeadAttributes = getAttributes()
       await documentTypeListStore.fetchDocumentTypes()


### PR DESCRIPTION
Закоментировал строки, отвечающие за серверную пагинацию в  data-grid (т.к. из-за отключения пагинации беками таблица работала некоректно)